### PR TITLE
 torch implementation of rmat to angle axis

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -59,16 +59,30 @@ class Tester(unittest.TestCase):
         self.assertTrue(res)
 
     def test_rotation_matrix_to_angle_axis_torch(self):
-        rmat = torch.tensor([[-0.30382753, -0.95095137, -0.05814062,  0.],
-                             [-0.71581715,  0.26812278, -0.64476041,  0.],
-                             [ 0.62872461, -0.15427791, -0.76217038,  0.],
-                             [ 0.        ,  0.        ,  0.        ,  1.]])
-        rvec = torch.tensor([1.50485376, -2.10737739,  0.7214174 ])
+        rmat_1 = torch.tensor([[-0.30382753, -0.95095137, -0.05814062, 0.],
+                             [-0.71581715,  0.26812278, -0.64476041,   0.],
+                             [ 0.62872461, -0.15427791, -0.76217038,   0.],
+                             [ 0.        ,  0.        ,  0.        ,   1.]])
+        rvec_1 = torch.tensor([1.50485376, -2.10737739,  0.7214174 ])
+
+        rmat_2 = torch.tensor([[ 0.6027768,  -0.79275544, -0.09054801, 0.],
+                               [-0.67915707, -0.56931658,  0.46327563, 0.],
+                               [-0.41881476, -0.21775548, -0.88157628, 0.],
+                               [ 0.       ,   0.        ,  0.        , 1.]])
+        rvec_2 = torch.tensor([-2.44916812, 1.18053411 , 0.4085298 ])
+        rmat = torch.stack([rmat_2, rmat_1], dim=0)
+        rvec = torch.stack([rvec_2, rvec_1], dim=0)
         self.assertTrue(check_equal_torch(tf.rotation_matrix_to_angle_axis(rmat), rvec))
 
     def test_rotation_matrix_to_angle_axis_gradcheck(self):
-        print('test_rotation_matrix_to_angle_axis_gradcheck to be implemented :)')
-        self.assertTrue(True)
+        # generate input data
+        batch_size = 2
+        rmat = torch.rand(batch_size, 4, 4)
+        rmat = utils.tensor_to_gradcheck_var(rmat)  # to var
+
+        # evaluate function gradient
+        res = gradcheck(tf.rotation_matrix_to_angle_axis, (rmat,), raise_exception=True)
+        self.assertTrue(res)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In this PR I have implemented rmat-2-quaternion based on this [repo](https://github.com/KieranWynn/pyquaternion/blob/master/pyquaternion/quaternion.py#L201). The reason for this new implementation is that I couldn't find a clean way to convert the [previous implementation](https://github.com/arraiy/torchgeometry/blob/master/torchgeometry/transforms/functional.py#L153) to support batched input.
I have also added [tests](https://github.com/arraiy/torchgeometry/blob/rotMat-to-angle/test/test_transforms.py#L61)  and the result is compatible with [arraiy/base/geometry_test.py](https://github.com/arraiy/workspace/blob/master/arraiy/base/geometry_test.py#L20)

But I don't know why the score of test_transform.py is 93%
![image](https://user-images.githubusercontent.com/5246494/46175306-585dee80-c260-11e8-8cda-763cc859a7f9.png)
