### PR TITLE
Make torchgeometry jit compatible

### DIFF
--- a/test/test_jit_tracing.py
+++ b/test/test_jit_tracing.py
@@ -17,7 +17,8 @@ class WarpPerspective(nn.Module):
     def forward(self, x, M):
 
         x = tgm.warp_perspective(x, M,
-            dsize=(self.output_height, self.output_width))
+                                 dsize=(self.output_height,
+                                        self.output_width))
 
         return x
 
@@ -32,7 +33,8 @@ class WarpAffine(nn.Module):
     def forward(self, x, M):
 
         x = tgm.warp_affine(x, M,
-            dsize=(self.output_height, self.output_width))
+                            dsize=(self.output_height,
+                                   self.output_width))
 
         return x
 
@@ -54,10 +56,6 @@ class LocalizationNetwork(nn.Module):
         else:
             self.linear = nn.Linear(256 * 3 * 3, 9)
             self.warper = WarpPerspective(output_size)
-
-        #self.linear.weight.data.zero_()
-        #self.linear.bias.data.copy_(torch.tensor([1, 0, 0, 0, 1, 0, 0, 0, 1], dtype=torch.float))
-        #self.linear.bias.data.copy_(torch.tensor([1, 0, 0, 0, 1, 0], dtype=torch.float))
 
     def forward(self, x):
         bs = x.size(0)

--- a/test/test_jit_tracing.py
+++ b/test/test_jit_tracing.py
@@ -1,0 +1,102 @@
+import pytest
+from common import TEST_DEVICES
+
+import torch
+import torchgeometry as tgm
+import torch.nn as nn
+import torchvision.models as models
+
+
+class WarpPerspective(nn.Module):
+
+    def __init__(self, output_size):
+        super(WarpPerspective, self).__init__()
+
+        self.output_height, self.output_width = output_size
+
+    def forward(self, x, M):
+
+        x = tgm.warp_perspective(x, M,
+            dsize=(self.output_height, self.output_width))
+
+        return x
+
+
+class WarpAffine(nn.Module):
+
+    def __init__(self, output_size):
+        super(WarpAffine, self).__init__()
+
+        self.output_height, self.output_width = output_size
+
+    def forward(self, x, M):
+
+        x = tgm.warp_affine(x, M,
+            dsize=(self.output_height, self.output_width))
+
+        return x
+
+
+class LocalizationNetwork(nn.Module):
+
+    def __init__(self, output_size, pretrained=True, affine=True):
+        super(LocalizationNetwork, self).__init__()
+
+        self.cnn = models.__dict__['alexnet'](pretrained=pretrained)
+        self.cnn = nn.Sequential(*list(self.cnn.children())[0])
+        self.cnn = nn.Sequential(*list(self.cnn.children())[:-1])
+
+        self.affine = affine
+
+        if self.affine:
+            self.linear = nn.Linear(256 * 3 * 3, 6)
+            self.warper = WarpAffine(output_size)
+        else:
+            self.linear = nn.Linear(256 * 3 * 3, 9)
+            self.warper = WarpPerspective(output_size)
+
+        #self.linear.weight.data.zero_()
+        #self.linear.bias.data.copy_(torch.tensor([1, 0, 0, 0, 1, 0, 0, 0, 1], dtype=torch.float))
+        #self.linear.bias.data.copy_(torch.tensor([1, 0, 0, 0, 1, 0], dtype=torch.float))
+
+    def forward(self, x):
+        bs = x.size(0)
+
+        inp_height = x.size(2)
+        inp_width = x.size(3)
+
+        x_down = nn.functional.interpolate(x, size=(64, 64), mode='bilinear')
+
+        M = self.linear(self.cnn(x_down).view(bs, -1))
+        if self.affine:
+            M = M.view(-1, 2, 3)
+        else:
+            M = M.view(-1, 3, 3)
+
+        out = self.warper(x, M)
+
+        return (out, M)
+
+
+@pytest.mark.parametrize("device_type", TEST_DEVICES)
+@pytest.mark.parametrize("affine", [True, False])
+def test_jit_tracing(device_type, affine):
+
+    net = LocalizationNetwork((128, 128), pretrained=False, affine=affine)
+    net.eval()
+
+    net = net.to(torch.device(device_type))
+
+    dummy_input = torch.randn(1, 3, 128, 128)
+    dummy_input = dummy_input.to(torch.device(device_type))
+
+    output = net(dummy_input)
+
+    traced_net = torch.jit.trace(net, dummy_input)
+    traced_output = traced_net(dummy_input)
+
+    out_comp1 = float(torch.mean((output[0] == traced_output[0]).float()))
+    out_comp2 = float(torch.mean((output[1] == traced_output[1]).float()))
+
+    assert(out_comp1 == 1.0)
+    assert(out_comp2 == 1.0)

--- a/torchgeometry/conversions.py
+++ b/torchgeometry/conversions.py
@@ -117,6 +117,7 @@ def convert_points_to_homogeneous(points):
 
     return nn.functional.pad(points, (0, 1), "constant", 1.0)
 
+
 def transform_points(dst_pose_src, points_src):
     r"""Function that applies transformations to a set of points.
 

--- a/torchgeometry/conversions.py
+++ b/torchgeometry/conversions.py
@@ -116,7 +116,8 @@ def convert_points_to_homogeneous(points):
             points.shape))
 
     if torch.is_tensor(points.shape[-1]):
-        last_dim_bit_length = torch.floor(torch.log2(points.shape[-1].float())) + 1
+        last_dim_shape = points.shape[-1].float()
+        last_dim_bit_length = torch.floor(torch.log2(last_dim_shape)) + 1
         last_dim_bit_length = last_dim_bit_length.long()
     else:
         last_dim_bit_length = points.shape[-1].bit_length()

--- a/torchgeometry/conversions.py
+++ b/torchgeometry/conversions.py
@@ -115,8 +115,15 @@ def convert_points_to_homogeneous(points):
         raise ValueError("Input must be at least a 2D tensor. Got {}".format(
             points.shape))
 
+    if torch.is_tensor(points.shape[-1]):
+        last_dim_bit_length = torch.floor(torch.log2(points.shape[-1].float())) + 1
+        last_dim_bit_length = last_dim_bit_length.long()
+    else:
+        last_dim_bit_length = points.shape[-1].bit_length()
+
     # create shape for ones tensor: Nx(...)xD-1
-    new_shape = points.shape[:-1] + (points.shape[-1].bit_length() - 1,)
+    # new_shape = points.shape[:-1] + (int(points.shape[-1]).bit_length() - 1,)
+    new_shape = points.shape[:-1] + (last_dim_bit_length - 1,)
     ones = torch.ones(new_shape, dtype=points.dtype)
     return torch.cat([points, ones.to(points.device)], dim=-1)
 

--- a/torchgeometry/conversions.py
+++ b/torchgeometry/conversions.py
@@ -115,19 +115,7 @@ def convert_points_to_homogeneous(points):
         raise ValueError("Input must be at least a 2D tensor. Got {}".format(
             points.shape))
 
-    if torch.is_tensor(points.shape[-1]):
-        last_dim_shape = points.shape[-1].float()
-        last_dim_bit_length = torch.floor(torch.log2(last_dim_shape)) + 1
-        last_dim_bit_length = last_dim_bit_length.long()
-    else:
-        last_dim_bit_length = points.shape[-1].bit_length()
-
-    # create shape for ones tensor: Nx(...)xD-1
-    # new_shape = points.shape[:-1] + (int(points.shape[-1]).bit_length() - 1,)
-    new_shape = points.shape[:-1] + (last_dim_bit_length - 1,)
-    ones = torch.ones(new_shape, dtype=points.dtype)
-    return torch.cat([points, ones.to(points.device)], dim=-1)
-
+    return nn.functional.pad(points, (0, 1), "constant", 1.0)
 
 def transform_points(dst_pose_src, points_src):
     r"""Function that applies transformations to a set of points.

--- a/torchgeometry/imgwarp.py
+++ b/torchgeometry/imgwarp.py
@@ -16,11 +16,9 @@ __all__ = [
 
 def normal_transform_pixel(height, width):
 
-    tr_mat = torch.Tensor([
-        [1.0, 0.0, -1.0],
-        [0.0, 1.0, -1.0],
-        [0.0, 0.0, 1.0]
-    ]) # 1x3x3
+    tr_mat = torch.Tensor([[1.0, 0.0, -1.0],
+                           [0.0, 1.0, -1.0],
+                           [0.0, 0.0, 1.0]])  # 1x3x3
 
     tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / (width - 1.0)
     tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / (height - 1.0)


### PR DESCRIPTION
In order to enable JIT tracing, following modifications are made.

1. `torchgeometry/conversions.py` : Bit length in `convert_points_to_homogeneous` is calculated using torch methods. (if we trace the model using JIT, `points.shape[-1]` is of type `torch.Tensor` instead of `int`.)
2. `torchgeometry/homography_warper.py` : `padding_mode` argument is moved from `forward` method to initialization of `HomographyWarper` since  JIT does not allow strings as arguments in `forward` methods.
3. `torchgeometry/imgwarp.py` : 
    * Tensor in `normal_transform_pixel` is created using arithmetic operations instead of replacement.
    * Generation of a 3x3 transformation matrix from 2x3 affine in `dst_norm_to_dst_norm` is updated in order to get rid of replacement of `M` to `M_3x3`.
4. `test/test_jit_tracing.py` is added in order to test JIT tracing.